### PR TITLE
fix(vault-contract): add constructor input validation

### DIFF
--- a/apps/smart-contracts/contracts/vault-contract/src/error.rs
+++ b/apps/smart-contracts/contracts/vault-contract/src/error.rs
@@ -9,6 +9,8 @@ pub enum ContractError {
     ExchangeIsCurrentlyDisabled = 3,
     BeneficiaryHasNoTokensToClaim = 4,
     VaultDoesNotHaveEnoughUSDC = 5,
+    InvalidRoiPercentage = 6,
+    TokenAndUsdcMustDiffer = 7,
 }
 
 impl fmt::Display for ContractError {
@@ -26,6 +28,12 @@ impl fmt::Display for ContractError {
             }
             ContractError::VaultDoesNotHaveEnoughUSDC => {
                 write!(f, "Vault does not have enough USDC")
+            }
+            ContractError::InvalidRoiPercentage => {
+                write!(f, "ROI percentage must be between 0 and 10000")
+            }
+            ContractError::TokenAndUsdcMustDiffer => {
+                write!(f, "Token and USDC addresses must be different")
             }
         }
     }

--- a/apps/smart-contracts/contracts/vault-contract/src/test.rs
+++ b/apps/smart-contracts/contracts/vault-contract/src/test.rs
@@ -611,3 +611,76 @@ fn test_high_roi_percentage() {
     vault.claim(&beneficiary);
     assert_eq!(usdc_client.balance(&beneficiary), 200);
 }
+
+// ============ Constructor Validation Tests (#24) ============
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_constructor_rejects_negative_roi() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (usdc_client, _) = create_usdc_token(&env, &admin);
+    let token = create_token_factory(&env, &token_admin);
+
+    create_vault(&env, &admin, false, -1, &token.address, &usdc_client.address);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_constructor_rejects_excessive_roi() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (usdc_client, _) = create_usdc_token(&env, &admin);
+    let token = create_token_factory(&env, &token_admin);
+
+    // ROI_MAX is 10_000, so 10_001 should fail
+    create_vault(&env, &admin, false, 10_001, &token.address, &usdc_client.address);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_constructor_rejects_token_equals_usdc() {
+    let env = Env::default();
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (usdc_client, _) = create_usdc_token(&env, &admin);
+    // Use the same address for both token and usdc
+    let _ = create_token_factory(&env, &token_admin);
+
+    create_vault(&env, &admin, false, 10, &usdc_client.address, &usdc_client.address);
+}
+
+#[test]
+fn test_constructor_accepts_zero_roi() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (usdc_client, _) = create_usdc_token(&env, &admin);
+    let token = create_token_factory(&env, &token_admin);
+
+    let vault = create_vault(&env, &admin, true, 0, &token.address, &usdc_client.address);
+    assert_eq!(vault.get_roi_percentage(), 0);
+}
+
+#[test]
+fn test_constructor_accepts_max_roi() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+
+    let (usdc_client, _) = create_usdc_token(&env, &admin);
+    let token = create_token_factory(&env, &token_admin);
+
+    let vault = create_vault(&env, &admin, true, 10_000, &token.address, &usdc_client.address);
+    assert_eq!(vault.get_roi_percentage(), 10_000);
+}

--- a/apps/smart-contracts/contracts/vault-contract/src/vault.rs
+++ b/apps/smart-contracts/contracts/vault-contract/src/vault.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contract, contractimpl, contracttype, token, Address, Env};
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, token, Address, Env};
 use token::Client as TokenClient;
 
 use crate::error::ContractError;
@@ -45,6 +45,9 @@ pub struct ClaimPreview {
 #[contract]
 pub struct VaultContract;
 
+/// Maximum allowed ROI percentage (10000 = 10000%)
+const ROI_MAX: i128 = 10_000;
+
 #[contractimpl]
 impl VaultContract {
     // ============ Constructor ============
@@ -54,9 +57,13 @@ impl VaultContract {
     /// # Arguments
     /// * `admin` - The address that will control vault availability
     /// * `enabled` - Initial state of whether claiming is enabled
-    /// * `roi_percentage` - The ROI percentage (e.g., 5 for 5% return)
-    /// * `token` - The token factory address
-    /// * `usdc` - The USDC stablecoin contract address
+    /// * `roi_percentage` - The ROI percentage (e.g., 5 for 5% return). Must be 0..=10000.
+    /// * `token` - The token factory address (must differ from `usdc`)
+    /// * `usdc` - The USDC stablecoin contract address (must differ from `token`)
+    ///
+    /// # Panics
+    /// * If `roi_percentage` is negative or greater than `ROI_MAX`
+    /// * If `token` and `usdc` are the same address
     pub fn __constructor(
         env: Env,
         admin: Address,
@@ -65,6 +72,14 @@ impl VaultContract {
         token: Address,
         usdc: Address,
     ) {
+        if roi_percentage < 0 || roi_percentage > ROI_MAX {
+            panic_with_error!(&env, ContractError::InvalidRoiPercentage);
+        }
+
+        if token == usdc {
+            panic_with_error!(&env, ContractError::TokenAndUsdcMustDiffer);
+        }
+
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Enabled, &enabled);
         env.storage()


### PR DESCRIPTION
## Summary
- Validate `roi_percentage` is in range `0..=10000` (panic with `InvalidRoiPercentage` if out of bounds)
- Reject `token == usdc` (panic with `TokenAndUsdcMustDiffer`)
- Add 2 new `ContractError` variants with `Display` impl
- Add 5 constructor validation tests (negative ROI, excessive ROI, token==usdc, zero ROI boundary, max ROI boundary)
- Note: Soroban has no zero-address concept, so "reject zero address" is not applicable

Closes #24

## Test plan
- [x] All 28 vault-contract tests pass (23 existing + 5 new)
- [x] `test_constructor_rejects_negative_roi` — panics with `Error(Contract, #6)`
- [x] `test_constructor_rejects_excessive_roi` — panics with `Error(Contract, #6)`
- [x] `test_constructor_rejects_token_equals_usdc` — panics with `Error(Contract, #7)`
- [x] `test_constructor_accepts_zero_roi` — boundary: ROI=0 accepted
- [x] `test_constructor_accepts_max_roi` — boundary: ROI=10000 accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)